### PR TITLE
Feat/support additional http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,44 +4,11 @@
 
   **Compatible with Urlbox API:** `v1`
 
-  A list of options that you can pass into [ExUrlBox.get/3](./lib/ex_urlbox.ex#L16) can be found here:
+  A list of options that you can pass into `ExUrlBox.get/3`, `ExUrlBox.post/3`, `ExUrlBox.head/3`, and `ExUrlBox.delete/3` can be found here:
   https://urlbox.io/docs/options
 
 
-
-
-## Usage
-  ```elixir
-      # Simple
-      ExUrlbox.get("https://anthonymineo.com")
-
-      # With options:
-      ExUrlbox.get("https://anthonymineo.com", [format: "png", full_page: true])
-
-      # With a timeout (5s):
-      ExUrlbox.get("https://anthonymineo.com", [], 5_000)
-
-
-      # Extract data from a response
-
-      {:ok, screenshot} = ExUrlbox.get("https://anthonymineo.com")
-
-      screenshot.body
-      # => <<137, 80, 78, 71, 13, ...>>>
-
-      screenshot.headers
-      # => [{"content-type", "image/png"}, ...]
-
-      screenshot.url
-      # => https://api.urlbox.io/v1/:apikey/hmac(:apisecret)/png?url=https%3A%2F%2Fwww.google.com&width=1024&height=768
-
-  ```
-
-
-
-
 ## Installation
-
 This package can be installed by adding `ex_urlbox` to your list of dependencies in `mix.exs`:
 
 ```elixir
@@ -53,9 +20,102 @@ end
 ```
 
 
+## Example Usage
+
+### GET - Synchronous
+  ```elixir
+  # Simple
+  ExUrlbox.get("https://anthonymineo.com")
+
+  # With options:
+  ExUrlbox.get("https://anthonymineo.com", [format: "png", full_page: true])
+
+  # With a timeout (5s):
+  ExUrlbox.get("https://anthonymineo.com", [], 5_000)
+
+
+  # Extract data from a response
+  {:ok, screenshot} = ExUrlbox.get("https://anthonymineo.com")
+
+  screenshot.body
+  # => <<137, 80, 78, 71, 13, ...>>>
+
+  screenshot.headers
+  # => [{"content-type", "image/png"}, ...]
+
+  screenshot.url
+  # => https://api.urlbox.io/v1/:apikey/hmac(:apisecret)/png?url=https%3A%2F%2Fwww.google.com&width=1024&height=768
+
+  ```
+
+### POST - Async with a webhook
+  Post a request to Urlbox for a screenshot.
+  You should provide a `webhook_url` option to receive a postback to once the screenshot render is complete.
+  ```elixir
+  # Example request with options containing `webhook_url` for a postback:
+  ExUrlbox.post("https://anthonymineo.com", [webhook_url: "https://app-waiting-for-incoming-post.com/"])
+  ```
+
+  **Initial response from a post:**
+  ```json
+  {
+    "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+    "status": "created",
+    "statusUrl": "https://api.urlbox.io/render/ebcbce5q-9657-435f-aeb6-5db207ee87b5"
+  }
+```
+
+**Example postback to `webhook_url`:**
+```json
+{
+  "event": "render.succeeded",
+  "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+  "result": {
+    "renderUrl": "https://renders.urlbox.io/urlbox1/renders/a1d7g7d45f7am5a0a69cd3de/2022/5/7/ebcbce5q-9657-435f-aeb6-5db207ee87b5.png",
+    "size": 34748
+  },
+  "meta": {
+    "startTime":"2022-05-07T20:25:28.879Z",
+    "endTime":"2022-05-07T20:25:31.646Z"
+  }
+}
+```
+
+
+**NOTE: If you dont provide a `webhook_url` you will need to poll the `statusUrl` for the status of your request:**
+```json
+/* GET => statusUrl */
+{
+  "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+  "status":	"succeeded",
+  "renderUrl": "https://renders.urlbox.io/urlbox1/renders/a1d7g7d45f7am5a0a69cd3de/2022/5/7/ebcbce5q-9657-435f-aeb6-5db207ee87b5.png",
+  "size": 34748
+}
+```
+
+### DELETE
+Urlbox will cache previously created screenshots for some time. Sending a delete request removes a previously created screenshot from the cache.
+
+**Example request:**
+```elixir
+ExUrlbox.delete("https://anthonymineo.com")
+```
+
+### HEAD
+If you just want to get the response status/headers without pulling down the full response body.
+
+**Example request:**
+```elixir
+ExUrlbox.head("https://anthonymineo.com")
+```
+
+
+
+
+
 
 ## Docs
-The docs can be found at [https://hexdocs.pm/ex_urlbox](https://hexdocs.pm/ex_urlbox).
+The full docs can be found at [https://hexdocs.pm/ex_urlbox](https://hexdocs.pm/ex_urlbox).
 
 Documentation has been generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ end
 ```
 
 
-**NOTE: If you dont provide a `webhook_url` you will need to poll the `statusUrl` for the status of your request:**
+**NOTE: If you dont provide a `webhook_url` you will need to poll the `statusUrl` that's included in the initial post response for the status of your request:**
 ```json
 /* GET => statusUrl */
 {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ExUrlbox
 
-  A light wrapper for the Urlbox API. ExUrlbox's documentation could be found on [HexDocs](https://hexdocs.pm/ex_urlbox).
+  A light wrapper for the Urlbox API written in Elixir. ExUrlbox's documentation could be found on [HexDocs](https://hexdocs.pm/ex_urlbox).
 
   **Compatible with Urlbox API:** `v1`
 
@@ -18,6 +18,23 @@ def deps do
   ]
 end
 ```
+
+### Configure the Urlbox API Key and Secret
+You can find your API Key and Secret [here](https://urlbox.io/dashboard/api).
+
+**Environment Vars (.env) -- refer to (.env.example)**
+```
+URLBOX_API_KEY="YoUrApIKeY"
+URLBOX_API_SECRET="YoUrApISeCreT"
+```
+
+**ExUrlbox will automatically look for the env vars listed above using the config below**
+```elixir
+config :ex_urlbox,
+  api_key: {:system, "URLBOX_API_KEY"},
+  api_secret: {:system, "URLBOX_API_SECRET"}
+```
+
 
 
 ## Example Usage

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -10,6 +10,11 @@ defmodule ExUrlbox.Config do
   # Config pattern inspired from https://github.com/danielberkompas/ex_twilio
 
   @doc """
+    Returns the default API endpoint. Used with POST requests
+  """
+  def base_endpoint, do: "https://api.urlbox.io/v1"
+
+  @doc """
   Returns the *URLBOX_API_KEY*
       config :ex_urlbox, api_key: "URLBOX_API_KEY"
   """
@@ -22,9 +27,14 @@ defmodule ExUrlbox.Config do
   def api_secret, do: from_env(:ex_urlbox, :api_secret)
 
   @doc """
-  Returns the default api endpoint
+  Returns the API endpoint with api_key for the following HTTP methods: GET, DELETE, HEAD
   """
-  def api_endpoint, do: "https://api.urlbox.io/v1/" <> api_key()
+  def api_key_endpoint, do: base_endpoint() <> api_key()
+
+  @doc """
+    Urlbox's API path for POST requests
+  """
+  def api_post_endpoint, do: "/render"
 
 
   @doc """

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -12,7 +12,7 @@ defmodule ExUrlbox.Config do
   @doc """
     Returns the default API endpoint. Used with POST requests
   """
-  def base_endpoint, do: "https://api.urlbox.io/v1"
+  def base_endpoint, do: "https://api.urlbox.io/v1/"
 
   @doc """
   Returns the *URLBOX_API_KEY*
@@ -34,7 +34,7 @@ defmodule ExUrlbox.Config do
   @doc """
     Urlbox's API path for POST requests
   """
-  def api_post_endpoint, do: "/render"
+  def api_post_endpoint, do: "render"
 
 
   @doc """

--- a/lib/ex_urlbox.ex
+++ b/lib/ex_urlbox.ex
@@ -4,22 +4,27 @@ defmodule ExUrlbox do
 
   **Compatible with Urlbox API Version:** `v1`
 
-  A list of options that you can pass into `ExUrlBox.get/3` can be found here:
+  A list of options that you can pass into `ExUrlBox.get/3`, `ExUrlBox.post/3`, `ExUrlBox.head/3`, and `ExUrlBox.delete/3` can be found here:
   https://urlbox.io/docs/options
   """
 
+  require Logger
   alias ExUrlbox.Config
+  alias ExUrlbox.Utils
+
   @adapter Tesla.Adapter.Hackney
-
-
+  @default_options [format: "png"]
 
   @doc """
   Send a request to Urlbox for a screenshot.
   Refer to the official documentation for all the available options: https://urlbox.io/docs/options
 
+    **This action is `synchronous`. **
+    If you want to use an `async` flow that uses webhooks, use `ExUrlBox.post/3`.
+
    **Function signature is: `url, [options], timeout`**
 
-    - Simple example:
+    - Example request:
     ```
     ExUrlbox.get("https://anthonymineo.com")
     ```
@@ -36,9 +41,9 @@ defmodule ExUrlbox do
 
   """
   @spec get(String.t(), list(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
-  def get(url, opts \\ [format: "png"], timeout \\ 30_000) when is_binary(url) and url != nil do
+  def get(url, opts \\ @default_options, timeout \\ 30_000) when is_binary(url) and url != nil do
     [{:url, url} | opts]
-    |> build_url()
+    |> Utils.build_url()
     |> client_get(timeout)
   end
 
@@ -47,56 +52,141 @@ defmodule ExUrlbox do
 
 
 
-
   @doc """
-  Generates a URL token by taking the HMAC SHA1 of the query string and signing it with your :api_secret.
+  Post a request to Urlbox for a screenshot.
+  You should provide a `webhook_url` option to receive a postback to once the screenshot render is complete.
 
-  Example URL Format:  `https://api.urlbox.io/v1/:api_key/hmac(:api_secret)/format?[options]`
+  **This action is `async`. **
+
+    - Example request with options containing `webhook_url` for a postback:
+    ```
+    ExUrlbox.post("https://anthonymineo.com", [webhook_url: "https://app-waiting-for-incoming-post.com/"])
+    ```
+
+    - Initial response from a post:
+    ```
+    {
+      "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+      "status": "created",
+      "statusUrl": "https://api.urlbox.io/render/ebcbce5q-9657-435f-aeb6-5db207ee87b5"
+    }
+    ```
+
+    - If you dont provide a `webhook_url` you will need to poll the `statusUrl` for the status of your request:
+    ```
+    {
+      "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+      "status":	"succeeded",
+      "renderUrl": "https://renders.urlbox.io/urlbox1/renders/a1d7g7d45f7am5a0a69cd3de/2022/5/7/ebcbce5q-9657-435f-aeb6-5db207ee87b5.png",
+      "size": 34748
+    }
+    ```
+
+    - Example of a postback to `webhook_url`:
+    ```
+    {
+      "event": "render.succeeded",
+      "renderId": "ebcbce5q-9657-435f-aeb6-5db207ee87b5",
+      "result": {
+        "renderUrl": "https://renders.urlbox.io/urlbox1/renders/a1d7g7d45f7am5a0a69cd3de/2022/5/7/ebcbce5q-9657-435f-aeb6-5db207ee87b5.png",
+        "size": 34748
+      },
+      "meta": {
+        "startTime":"2022-05-07T20:25:28.879Z",
+        "endTime":"2022-05-07T20:25:31.646Z"
+      }
+    }
+    ```
   """
-  @spec generate_url_token(String.t()) :: String.t()
-  def generate_url_token(opts) do
-    :crypto.mac(:hmac, :sha, Config.api_secret(), opts)
-    |> Base.encode16()
-    |> String.downcase()
+  @spec post(String.t(), list(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def post(url, opts \\ @default_options, timeout \\ 30_000) when is_binary(url) and url != nil do
+
+    if !Keyword.get(opts, :webhook_url) do
+      Logger.warning("webhook_url option was not found! You will need to poll the statusUrl from the post response for your results")
+    end
+
+    [{:url, url} | opts]
+    |> Enum.into(%{})
+    |> client_post(timeout)
   end
 
+  @doc false
+  def post, do: raise("No URL was passed in to screenshot!")
+
+
   @doc """
-  Build the screenshot request URL
+  Urlbox will cache previously created screenshots for some time. Sending a delete request removes a previously created screenshot from the cache.
 
-  Example URL:  `/png?url=https%3A%2F%2Fgoogle.com&width=1024&height=768"`
+    - Example request:
+    ```
+    ExUrlbox.delete("https://anthonymineo.com")
+    ```
   """
-  @spec build_url(list()) :: String.t()
-  def build_url(opts) do
-    uri_options =
-    opts
-    |> Keyword.delete(:format)
-    |> URI.encode_query()
-
-    tokend_options = uri_options |> generate_url_token()
-
-    [
-      tokend_options,
-      opts[:format]
-    ]
-    |> Enum.join("/")
-    |> Kernel.<>("?#{uri_options}")
+  @spec delete(String.t(), list(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def delete(url, opts \\ @default_options, timeout \\ 30_000) when is_binary(url) and url != nil do
+    [{:url, url} | opts]
+    |> Utils.build_url()
+    |> client_delete(timeout)
   end
+
+  @doc false
+  def delete, do: raise("No URL was passed in to screenshot!")
+
+
+
+  @doc """
+  If you just want to get the response status/headers without pulling down the full response body.
+
+    - Example request:
+    ```
+    ExUrlbox.head("https://anthonymineo.com")
+    ```
+  """
+  @spec head(String.t(), list(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def head(url, opts \\ @default_options, timeout \\ 30_000) when is_binary(url) and url != nil do
+    [{:url, url} | opts]
+    |> Utils.build_url()
+    |> client_head(timeout)
+  end
+
+  @doc false
+  def head, do: raise("No URL was passed in to screenshot!")
+
+
+
+
+
+
 
 
 
   # Setup Tesla client
   @doc false
-  @spec client(integer()) :: Tesla.Client.t()
-  def client(timeout) do
+  @spec client(integer(), bool()) :: Tesla.Client.t()
+  def client(timeout, is_post? \\ false) do
     middleware = [
-      {Tesla.Middleware.BaseUrl, Config.api_endpoint},
       {Tesla.Middleware.Timeout, timeout: timeout},
       Tesla.Middleware.JSON
     ]
+    |> determine_endpoint(is_post?)
 
     Tesla.client(middleware, @adapter)
   end
 
+  @doc false
+  @spec determine_endpoint(list(), boolean()) :: list()
+  defp determine_endpoint(middleware, is_post?) do
+    case is_post? do
+      true  -> [{Tesla.Middleware.BaseUrl, Config.base_endpoint} | middleware] |> include_bearer_token()
+      false -> [{Tesla.Middleware.BaseUrl, Config.api_key_endpoint} | middleware]
+    end
+  end
+
+  @doc false
+  @spec include_bearer_token(list()) :: list()
+  defp include_bearer_token(middleware) do
+    [{Tesla.Middleware.BearerAuth, token: Config.api_secret} | middleware]
+  end
 
 
   # Handle the HTTP GET
@@ -106,4 +196,33 @@ defmodule ExUrlbox do
     client(timeout)
     |> Tesla.get(opts)
   end
+
+
+  # Handle the HTTP DELETE
+  @doc false
+  @spec client_delete(String.t(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def client_delete(opts, timeout) do
+    client(timeout)
+    |> Tesla.delete(opts)
+  end
+
+
+  # Handle the HTTP HEAD
+  @doc false
+  @spec client_head(String.t(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def client_head(opts, timeout) do
+    client(timeout)
+    |> Tesla.head(opts)
+  end
+
+  # Handle the HTTP POST
+  @doc false
+  @spec client_post(String.t(), integer()) :: {:error, any()} | {:ok, Tesla.Env.t()}
+  def client_post(post_body, timeout) do
+    is_post? = true
+    client(timeout, is_post?)
+    |> Tesla.post(Config.api_post_endpoint, post_body)
+  end
+
+
 end

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -1,0 +1,53 @@
+defmodule ExUrlbox.Utils do
+  @moduledoc """
+  Various helper utilities for working with Urlbox's API
+
+  """
+
+  require Logger
+  alias ExUrlbox.Config
+
+
+
+
+  @doc """
+  Generates a URL token by taking the HMAC SHA1 of the query string and signing it with your :api_secret.
+
+    - Example URL Format:
+    ```html
+    https://api.urlbox.io/v1/:api_key/hmac(:api_secret)/format?[options]
+    ```
+  """
+  @spec generate_url_token(String.t()) :: String.t()
+  def generate_url_token(opts) do
+    :crypto.mac(:hmac, :sha, Config.api_secret(), opts)
+    |> Base.encode16()
+    |> String.downcase()
+  end
+
+  @doc """
+  Build the screenshot request URL. Used with `get`, `delete` and `head` requests.
+
+    - Example URL:
+    ```html
+    /png?url=https%3A%2F%2Fgoogle.com&width=1024&height=768"
+    ```
+  """
+  @spec build_url(list()) :: String.t()
+  def build_url(opts) do
+    uri_options =
+    opts
+    |> Keyword.delete(:format)
+    |> URI.encode_query()
+
+    tokend_options = uri_options |> generate_url_token()
+
+    [
+      tokend_options,
+      opts[:format]
+    ]
+    |> Enum.join("/")
+    |> Kernel.<>("?#{uri_options}")
+  end
+
+end


### PR DESCRIPTION
Adds support additional methods (post, head, delete)

### ExUrlBox.post/3

> This action is async. should provide a webhook_url option to receive a postback to once the screenshot render is complete.

### ExUrlBox.head/3

> If you just want to get the response status/headers without pulling down the full response body.

 ### ExUrlBox.delete/3

> Urlbox will cache previously created screenshots for some time. Sending a delete request removes a previously created screenshot from the cache.

